### PR TITLE
Add JAX to speeding up section

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Often, it is not needed anymore to write C++/C routines that get wrapped since t
 | [numba][] | Tight loops are often the slow part of Python code, where this JIT compiles them! |
 | [Pythran][] | Whole scripts |
 | [numpy][] | Expressing your code as array options means you get native-C speeds per sub-expression. |
-| [jax][] | Allows compiling and running numpy operations on accelerated hardware like GPU's. Also offers a JIT-compiler (less sofisticated than numba), automatic analytic differentiation (gradient) of python functions and efficient vectorization. Was developed with the aim of being able to develop efficient machine learning algorithms "from scratch" with numpy-like code. |
+| [jax][] | Allows compiling and running NumPy operations on accelerated hardware such as GPU's. Also offers a JIT compiler (less sophisticated than Numba), automatic analytic differentiation (gradient) of Python functions and efficient vectorization. Was developed with the aim of being able to develop efficient machine learning algorithms "from scratch" with NumPy-like code.
 | [NumExpr][] | Single pass "mapper" operations (one input &rarr; one output). |
 
 [numba]:   https://numba.pydata.org

--- a/README.md
+++ b/README.md
@@ -191,11 +191,13 @@ Often, it is not needed anymore to write C++/C routines that get wrapped since t
 | [numba][] | Tight loops are often the slow part of Python code, where this JIT compiles them! |
 | [Pythran][] | Whole scripts |
 | [numpy][] | Expressing your code as array options means you get native-C speeds per sub-expression. |
+| [jax][] | Allows compiling and running numpy operations on accelerated hardware like GPU's. Also offers a JIT-compiler (less sofisticated than numba), automatic analytic differentiation (gradient) of python functions and efficient vectorization. Was developed with the aim of being able to develop efficient machine learning algorithms "from scratch" with numpy-like code. |
 | [NumExpr][] | Single pass "mapper" operations (one input &rarr; one output). |
 
 [numba]:   https://numba.pydata.org
 [Pythran]: https://pythran.readthedocs.io/en/latest/
 [numpy]:   http://www.numpy.org
+[jax]:     Https://jax.readthedocs.io/en/latest/notebooks/quickstart.html
 [NumExpr]: https://numexpr.readthedocs.io/en/latest/user_guide.html
 
 ## Binding C/C++ to Python


### PR DESCRIPTION
I have to admit I haven't really much used JAX so far, my knowledge of it is based mostly on the [SciPy 2020 talk](https://youtu.be/z-WSrQDXkuM) and hearing people talk about it being one of the new cool things out there. But it's on my TODO-list, seems quite popular (it's google-backed after all) and production-ready and I think physicists could profit from it. Since JAX also offers a JIT, I put it into the speeding-up section.I'm no expert here so feel free to discuss this PR or reject it, it's just a suggestion. 

The JIT is according to the talk ([this part](https://youtu.be/z-WSrQDXkuM?t=1344)) less sophisticated than the one of numba, since it uses tracers and doesn't transpile python bytecode directly to LLVM.

Also the vectorization sounds like it might speed up things even on a single core, though I'm not sure how it compares to the other packages that offer the same feature (e.g. numexpr or I think numba as well).

The greatest advantage and spead-up potential is the ease of running numpy-like code on the GPU without needing tensorflow. But I'm not sure if this section includes speed-up via parallelization or running on GPU's, that could almost warrant it's own section, though there's a strong overlap with the Machinelearning table. I almost think this package could fit to machinelearning, since it is what it was originally meant for.

The coolest feature imo is the automatic analytic gradient calculation via `jax.grad` and I've already heard of people successfully using it, but that goes much beyond mere "speed-up"