### PR TITLE
docs: add cabinetry to package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,14 @@ General information through talks that may be useful on PyData (various conferen
 | [pyhf][] | Pure python implementation of HistFactory specification with auto-diff enabled backends in tensorflow, pytorch, and MXNet. |
 | [hepstats][] | HEP statistics tools and utilities. |
 | [zfit][] | Scalable pythonic fitting. |
+| [cabinetry][] | Constructing template fit models and steering statistical inference using pyhf. |
 
 [iminuit]: https://github.com/scikit-hep/iminuit
 [hepstats]: https://github.com/scikit-hep/hepstats
 [pyhf]: https://github.com/scikit-hep/pyhf
 [uncertainties]: https://github.com/lebigot/uncertainties
 [zfit]: https://github.com/zfit/zfit
+[cabinetry]: https://github.com/scikit-hep/cabinetry/
 
 ## Particle Physics packages
 | Name         | Use             |

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ General information through talks that may be useful on PyData (various conferen
 | [pyhf][] | Pure python implementation of HistFactory specification with auto-diff enabled backends in tensorflow, pytorch, and MXNet. |
 | [hepstats][] | HEP statistics tools and utilities. |
 | [zfit][] | Scalable pythonic fitting. |
-| [cabinetry][] | Constructing template fit models and steering statistical inference using pyhf. |
+| [cabinetry][] | Constructing binned template fit models and steering statistical inference using pyhf. |
 
 [iminuit]: https://github.com/scikit-hep/iminuit
 [hepstats]: https://github.com/scikit-hep/hepstats


### PR DESCRIPTION
Adding [`cabinetry`](https://github.com/scikit-hep/cabinetry/) to the package list in the readme, prompted by a comment by @eduardo-rodrigues in the PyHEP 2022 Slack.